### PR TITLE
🐛 Fix: 환율 페이지 API 연동 및 수정

### DIFF
--- a/src/pages/Rates/RateChart/RateChart.jsx
+++ b/src/pages/Rates/RateChart/RateChart.jsx
@@ -23,6 +23,14 @@ ChartJS.register(
 );
 
 export default function RateChart({ graphData }) {
+  const prices = graphData.map((item) => item.price);
+
+  // Y축 범위 설정 (여백 설정)
+  const dataMin = Math.min(...prices);
+  const dataMax = Math.max(...prices);
+  const dataRange = dataMax - dataMin;
+  const yAxisMin = dataMin - dataRange * 0.1;
+  const yAxisMax = dataMax + dataRange * 0.1;
   const data = {
     labels: graphData.map((item) => item.date), // X축 : 날짜
     datasets: [
@@ -83,6 +91,8 @@ export default function RateChart({ graphData }) {
         border: {
           display: false,
         },
+        min: yAxisMin,
+        max: yAxisMax,
       },
     },
   };

--- a/src/pages/Rates/Rates.jsx
+++ b/src/pages/Rates/Rates.jsx
@@ -26,156 +26,6 @@ const initialRateData = {
   data: [],
 };
 
-// API 확인용 더미 데이터
-const DUMMY_API_RESPONSE = {
-  isSuccess: true,
-  timeStamp: "2025-11-06 15:01:49",
-  code: "SUCCESS_200",
-  httpStatus: 200,
-  message: "호출에 성공했습니다.",
-  data: [
-    {
-      ExchangeRateData: {
-        currencyType: "USD",
-        todayRate: 1437.7,
-        rateCompareYesterday: 0.0,
-        priceGraphData: [
-          {
-            date: "2024-11-06",
-            price: 1377.8,
-          },
-          {
-            date: "2024-11-07",
-            price: 1391.5,
-          },
-          {
-            date: "2024-11-08",
-            price: 1399.1,
-          },
-          // ...
-          {
-            date: "2025-11-05",
-            price: 1437.7,
-          },
-        ],
-        eachBankFee: [
-          {
-            bank: "shinhan",
-            fee: 0.175,
-          },
-          {
-            bank: "hana",
-            fee: 0.175,
-          },
-          {
-            bank: "kookmin",
-            fee: 0.175,
-          },
-          {
-            bank: "woori",
-            fee: 0.175,
-          },
-        ],
-      },
-      toastMessage: "It's a good time to exchange your KRW today!",
-    },
-    {
-      ExchangeRateData: {
-        currencyType: "CNY",
-        todayRate: 201.9,
-        rateCompareYesterday: 0.0,
-        priceGraphData: [
-          {
-            date: "2024-11-06",
-            price: 193.95,
-          },
-          {
-            date: "2024-11-07",
-            price: 194.35,
-          },
-          {
-            date: "2024-11-08",
-            price: 194.32,
-          },
-
-          // ...
-
-          {
-            date: "2025-11-05",
-            price: 201.9,
-          },
-        ],
-        eachBankFee: [
-          {
-            bank: "shinhan",
-            fee: 2.0,
-          },
-          {
-            bank: "hana",
-            fee: 3.5,
-          },
-          {
-            bank: "kookmin",
-            fee: 3.0,
-          },
-          {
-            bank: "woori",
-            fee: 3.25,
-          },
-        ],
-      },
-      toastMessage: "It's a good time to exchange currency today!",
-    },
-    {
-      ExchangeRateData: {
-        currencyType: "VND",
-        todayRate: 5.46,
-        rateCompareYesterday: 0.0,
-        priceGraphData: [
-          {
-            date: "2024-11-06",
-            price: 5.44,
-          },
-          {
-            date: "2024-11-07",
-            price: 5.48,
-          },
-          {
-            date: "2024-11-08",
-            price: 5.52,
-          },
-
-          // ...
-
-          {
-            date: "2025-11-05",
-            price: 5.46,
-          },
-        ],
-        eachBankFee: [
-          {
-            bank: "shinhan",
-            fee: 6.6,
-          },
-          {
-            bank: "hana",
-            fee: 11.8,
-          },
-          {
-            bank: "kookmin",
-            fee: 9.6,
-          },
-          {
-            bank: "woori",
-            fee: null,
-          },
-        ],
-      },
-      toastMessage: "Not a good day to exchange money today!",
-    },
-  ],
-};
-
 export default function Rates() {
   const [exchangeRateData, setExchangeRateData] = useState(initialRateData);
   const [loading, setLoading] = useState(true);
@@ -198,10 +48,8 @@ export default function Rates() {
   const fetchExchangeRates = useCallback(async () => {
     setLoading(true);
     try {
-      // const res = await api.get("/api/exrate");
-      // setExchangeRateData(res.data);
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      setExchangeRateData(DUMMY_API_RESPONSE);
+      const res = await api.get("/api/exrate");
+      setExchangeRateData(res.data);
     } catch (error) {
       console.error("환율 데이터 로드 실패", error);
     } finally {
@@ -235,7 +83,8 @@ export default function Rates() {
       switch (period) {
         case "1_WEEK":
           startDate = new Date(today);
-          startDate.setDate(today.getDate() - 7);
+          // 영업일만 계산 (주말만큼 더해줌)
+          startDate.setDate(today.getDate() - 9);
           break;
         case "3_MONTHS":
           startDate = new Date(today);

--- a/src/pages/Rates/RatesStyle.js
+++ b/src/pages/Rates/RatesStyle.js
@@ -8,6 +8,16 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.875rem;
+  /* 스크롤 안 보이게 */
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
 `;
 
 export const TopBox = styled.div`


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->

#21 

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 환율 페이지 더미데이터 지우고 API에서 받아온 데이터 렌더링하도록 수정
  - 1 WEEK이 7일짜리가 아니라 9일짜리 받아오도록 수정 (주말 고려)
  - 그래프 아래로 여백 만듦 (border에 그래프가 닿지 않도록)
- 1 YEAR를 7일에 하나씩으로 데이터를 받을지 365일 다 받을지 -> 고민... 

## 📸 UI 작업 시

<!-- 이미지 or 영상 첨부 -->
<img width="384" height="895" alt="image" src="https://github.com/user-attachments/assets/e181ce7a-b8be-4f41-a1bb-3298c8419340" />


## ✅ 체크 리스트

<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
