### PR TITLE
Fix: 환율 상승률 직접 가공, 로딩 스피너 로직 수정

### DIFF
--- a/src/pages/Rates/RateChart/RateChart.jsx
+++ b/src/pages/Rates/RateChart/RateChart.jsx
@@ -10,6 +10,7 @@ import {
   Legend,
   Filler,
 } from "chart.js";
+import { useEffect, useRef } from "react";
 
 ChartJS.register(
   CategoryScale,
@@ -22,8 +23,22 @@ ChartJS.register(
   Filler
 );
 
-export default function RateChart({ graphData }) {
+export default function RateChart({ graphData, onLoadComplete }) {
+  const chartRef = useRef();
+  useEffect(() => {
+    if (graphData.length > 0 && chartRef.current && onLoadComplete) {
+      setTimeout(() => {
+        onLoadComplete();
+      }, 0);
+    }
+  }, [graphData, onLoadComplete]); // graphData나 콜백이 변경될 때마다 재실행
+
   const prices = graphData.map((item) => item.price);
+
+  // 데이터가 없으면 차트 렌더링하지 않음 (오류 방지 및 깔끔한 처리)
+  if (prices.length === 0) {
+    return null;
+  }
 
   // Y축 범위 설정 (여백 설정)
   const dataMin = Math.min(...prices);
@@ -99,7 +114,7 @@ export default function RateChart({ graphData }) {
 
   return (
     <div>
-      <Line data={data} options={options} />
+      <Line ref={chartRef} data={data} options={options} />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->


## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 환율 전날 대비 상승률 데이터 활용해 프론트에서 직접 가공
 - 서버에서 데이터가 직접 안 넘어오는 것 같아서 같이 넘어오는 데이터들로 가공해서 띄우도록 수정했습니다.
- 그래프까지 제대로 떠야 로딩 스피너 사라지도록 수정 

## 📸 UI 작업 시

<!-- 이미지 or 영상 첨부 -->
<img width="388" height="793" alt="image" src="https://github.com/user-attachments/assets/c6d7b073-bb9d-4874-8a34-68e2723f1c94" />


## ✅ 체크 리스트

<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
